### PR TITLE
Update main_ndp.cpp

### DIFF
--- a/sim/datacenter/main_ndp.cpp
+++ b/sim/datacenter/main_ndp.cpp
@@ -600,6 +600,10 @@ int main(int argc, char **argv) {
         //cout << "Connection " << crt->src << "->" <<crt->dst << " starting at " << crt->start << " size " << crt->size << endl;
 
         ndpSrc = new NdpSrc(NULL, NULL, eventlist,rts);
+        // If traffic logging is enabled, attach the per-packet traffic logger
+        if (log_traffic) {
+            ndpSrc->set_traffic_logger(&traffic_logger);
+        }
         ndpSrc->setCwnd(cwnd*Packet::data_packet_size());
         ndp_srcs.push_back(ndpSrc);
         ndpSrc->set_dst(dest);


### PR DESCRIPTION
Attach the traffic logger to NDP source so that logging with the `-log traffic` command works properly. Out of the box, using the -log flag for main_ndp does not seem to do anything if the traffic flag is passed. This fixes it.